### PR TITLE
2222 fix percent formats 2

### DIFF
--- a/dist/recline.view.nvd3.controls.min.js
+++ b/dist/recline.view.nvd3.controls.min.js
@@ -36,9 +36,10 @@ my.BaseControl = Backbone.View.extend({
                       '<option data-type="Number" value="$,">$100,000</option>' +
                     '</optgroup>' +
                     '<optgroup label="Percentage">' +
-                      '<option data-type="Number" value="%d">100,000%</option>' +
-                      '<option data-type="Number" value="%,.1f">100,000.0%</option>' +
-                      '<option data-type="Number" value="%,.2f">100,000.00%</option>' +
+                      '<option data-type="Percentage" value="%">.97 -> 97%</option>' +
+                      '<option data-type="Percentage" value="p,.2f">.97 -> 97.00%</option>' +
+                      '<option data-type="PercentageA" value="d">97 -> 97%</option>' +
+                      '<option data-type="PercentageA" value="">97 -> 97.00%</option>' +
                     '</optgroup>' +
                 '</select>' +
               '</div>' +
@@ -113,9 +114,10 @@ my.BaseControl = Backbone.View.extend({
                       '<option data-type="Number" value="$,">$100,000</option>' +
                     '</optgroup>' +
                     '<optgroup label="Percentage">' +
-                      '<option data-type="Percentage" value="d">100,000%</option>' +
-                      '<option data-type="Percentage" value=",.1f">100,000.0%</option>' +
-                      '<option data-type="Percentage" value=",.2f">100,000.00%</option>' +
+                      '<option data-type="Percentage" value="%">.97 -> 97%</option>' +
+                      '<option data-type="PercentageB" value=".2f">.97 -> 97.00%</option>' +
+                      '<option data-type="PercentageA" value=".0f">97 -> 97%</option>' +
+                      '<option data-type="PercentageA" value=".2f">97 -> 97.00%</option>' +
                     '</optgroup>' +
                   '</select>' +
                 '</div>' +
@@ -178,9 +180,9 @@ my.BaseControl = Backbone.View.extend({
                       '<option data-type="Number" value="$,">$100,000</option>' +
                     '</optgroup>' +
                     '<optgroup label="Percentage">' +
-                      '<option data-type="Percentage" value="d">100,000%</option>' +
-                      '<option data-type="Percentage" value=",.1f">100,000.0%</option>' +
-                      '<option data-type="Percentage" value=",.2f">100,000.00%</option>' +
+                      '<option data-type="Percentage" value="%">.97 -> 97%</option>' +
+                      '<option data-type="Percentage" value="p,.2f">.97 -> 97.00%</option>' +
+                      '<option data-type="PercentageA" value="">97 -> 97.00%</option>' +
                     '</optgroup>' +
                   '</select>' +
                 '</div>' +
@@ -243,9 +245,10 @@ my.BaseControl = Backbone.View.extend({
                       '<option data-type="Number" value="$,">$100,000</option>' +
                     '</optgroup>' +
                     '<optgroup label="Percentage">' +
-                      '<option data-type="Percentage" value="d">100,000%</option>' +
-                      '<option data-type="Percentage" value=",.1f">100,000.0%</option>' +
-                      '<option data-type="Percentage" value=",.2f">100,000.00%</option>' +
+                      '<option data-type="Percentage" value="%">.97 -> 97%</option>' +
+                      '<option data-type="Percentage" value="p,.2f">.97 -> 97.00%</option>' +
+                      '<option data-type="PercentageA" value="d">97 -> 97%</option>' +
+                      '<option data-type="PercentageA" value="">97 -> 97.00%</option>' +
                     '</optgroup>' +
                   '</select>' +
                 '</div>' +

--- a/dist/recline.view.nvd3.min.js
+++ b/dist/recline.view.nvd3.min.js
@@ -353,15 +353,11 @@ var chartAxes = ['x','y','y1','y2'];
           'String': _.identity,
           'Date': _.compose(d3.time.format(format || '%x'),_.instantiate(Date)),
           'Number': d3.format(format || '.02f'),
-          'Percentage': self.formatPercentage(format || '.02f'),
+          'Percentage': d3.format(format || '.02f'),
+          'PercentageA': function (n) { return d3.format(format || '.02f')(n) + '%'; },
+          'PercentageB': function (n) { return d3.format(format || '.02f')(n*100) + '%'; },
         };
         return formatter[type];
-      },
-      formatPercentage: function(format) {
-        if (format === 'd') format = 'r.0';
-        return function(d){
-          return d3.format(format)(d) + '%';
-        };
       },
       setOptions: function (chart, options) {
         var self = this;

--- a/src/controls/recline.view.nvd3.baseControl.js
+++ b/src/controls/recline.view.nvd3.baseControl.js
@@ -1,6 +1,7 @@
 /*jshint multistr:true */
 this.recline = this.recline || {};
 this.recline.View = this.recline.View || {};
+
 ;(function ($, my) {
 'use strict';
 
@@ -181,7 +182,6 @@ my.BaseControl = Backbone.View.extend({
                     '<optgroup label="Percentage">' +
                       '<option data-type="Percentage" value="%">.97 -> 97%</option>' +
                       '<option data-type="Percentage" value="p,.2f">.97 -> 97.00%</option>' +
-                      '<option data-type="PercentageA" value="d">97 -> 97%</option>' +
                       '<option data-type="PercentageA" value="">97 -> 97.00%</option>' +
                     '</optgroup>' +
                   '</select>' +
@@ -200,81 +200,11 @@ my.BaseControl = Backbone.View.extend({
                     '</div>' +
                   '</div>' +
                 '</div>' +
-<<<<<<< HEAD
 
                 /// Axis ticks
                 '<div class="form-group">' +
                   '<div class="row">' +
                     '<div class="col-md-9 col-sm-9">' +
-                      '<label for="control-chart-y1-values">Tick Values</label>' +
-                      '<input class="form-control" placeholder="From.." type="text" id="control-chart-y1-values-from" value="{{y1ValuesFrom}}"/>' +
-                      '<input class="form-control" placeholder="To.." type="text" id="control-chart-y1-values-to" value="{{y1ValuesTo}}"/>' +
-                    '</div>' +
-                    '<div class="col-md-3 col-sm-3">' +
-                      '<label for="control-chart-y1-values-step">Step</label>' +
-                      '<input class="form-control" type="number" id="control-chart-y1-values-step" value="{{y1ValuesStep}}"/>' +
-                    '</div>' +
-                  '</div>' +
-                '</div>' +
-              '</fieldset>',
-  templateY2Format: 
-              //////// Y2 AXIS
-              '<fieldset>' +
-                '<legend>Y-2 Axis</legend>' +
-
-                /// Format
-                '<div class="form-group">' +
-                  '<label for="control-chart-y2-format">Format</label>' +
-                  '<select class="form-control" id="control-chart-y2-format">' +
-                    '<optgroup label="Text">' +
-                      '<option data-type="String" value="">Text</option>' +
-                    '</optgroup>' +
-                    '<optgroup label="Numbers">' +
-                      '<option data-type="Number" value="d">100,000</option>' +
-                      '<option data-type="Number" value=",.1f">100,000.0</option>' +
-                      '<option data-type="Number" value=",.2f">100,000.00</option>' +
-                      '<option data-type="Number" value="s">100K</option>' +
-                    '</optgroup>' +
-                    '<optgroup label="Date">' +
-                      '<option data-type="Date" value="%m/%d/%Y">mm/dd/yyyy</option>' +
-                      '<option data-type="Date" value=""%m-%d-%Y">mm-dd-yyyy</option>' +
-                      '<option data-type="Date" value="%Y">Year</option>' +
-                    '</optgroup>' +
-                    '<optgroup label="Currency">' +
-                      '<option data-type="Number" value="$,.2f">$100,000.00</option>' +
-                      '<option data-type="Number" value="$,.1f">$100,000.0</option>' +
-                      '<option data-type="Number" value="$,">$100,000</option>' +
-                    '</optgroup>' +
-                    '<optgroup label="Percentage">' +
-                      '<option data-type="Percentage" value="d">100,000%</option>' +
-                      '<option data-type="Percentage" value=",.1f">100,000.0%</option>' +
-                      '<option data-type="Percentage" value=",.2f">100,000.00%</option>' +
-                    '</optgroup>' +
-                  '</select>' +
-                '</div>' +
-
-                /// Axis label
-                '<div class="form-group">' +
-                  '<div class="row">' +
-                    '<div class="col-md-9 col-sm-9">' +
-                      '<label for="control-chart-y2-axis-label">Y Axis Label</label>' +
-                      '<input class="form-control" type="text" id="control-chart-y2-axis-label" value="{{options.y2Axis.axisLabel}}"/>' +
-                    '</div>' +
-                    '<div class="col-md-3 col-sm-3">' +
-                      '<label for="control-chart-y2-axis-label-distance">Distance</label>' +
-                      '<input class="form-control" type="number" id="control-chart-y2-axis-label-distance" value="{{options.y2Axis.axisLabelDistance}}"/>' +
-                    '</div>' +
-                  '</div>' +
-                '</div>' +
-=======
->>>>>>> 2222-fix-percent-formats
-
-                /// Axis ticks
-                '<div class="form-group">' +
-                  '<div class="row">' +
-                    '<div class="col-md-9 col-sm-9">' +
-<<<<<<< HEAD
-=======
                       '<label for="control-chart-y1-values">Tick Values</label>' +
                       '<input class="form-control" placeholder="From.." type="text" id="control-chart-y1-values-from" value="{{y1ValuesFrom}}"/>' +
                       '<input class="form-control" placeholder="To.." type="text" id="control-chart-y1-values-to" value="{{y1ValuesTo}}"/>' +
@@ -341,7 +271,6 @@ my.BaseControl = Backbone.View.extend({
                 '<div class="form-group">' +
                   '<div class="row">' +
                     '<div class="col-md-9 col-sm-9">' +
->>>>>>> 2222-fix-percent-formats
                       '<label for="control-chart-y2-values">Tick Values</label>' +
                       '<input class="form-control" placeholder="From.." type="text" id="control-chart-y2-values-from" value="{{y2ValuesFrom}}"/>' +
                       '<input class="form-control" placeholder="To.." type="text" id="control-chart-y2-values-to" value="{{y2ValuesTo}}"/>' +
@@ -478,22 +407,13 @@ my.BaseControl = Backbone.View.extend({
   
   linePlusBarXSelect: function () {
     var self = this;
-<<<<<<< HEAD
     var markup = '<fieldset><legend>Bar Chart Series</legend>' +
                  '<p>Select which series should be represented as a bar chart</p>' +
-=======
-    var markup = '<legend>Bar Chart Series</legend>' +
-                 '<p>Select which series should be represented as a bard chart</p>' +
->>>>>>> 2222-fix-percent-formats
                  '<select id="control-lpb-barchart-field">';
     this.state.get('seriesFields').forEach(function (field) {
                   markup += '<option value="' + field + '">' + field + '</option>';
     });
-<<<<<<< HEAD
                  markup += '</select></fieldset>';
-=======
-                 markup += '</select>';
->>>>>>> 2222-fix-percent-formats
     return markup;
   },
 
@@ -502,7 +422,6 @@ my.BaseControl = Backbone.View.extend({
     
     template += this.templateTop;
     template += this.templateXFormat;
-<<<<<<< HEAD
 
     if (this.state.get('graphType') === 'linePlusBarChart') {
       template += this.templateY1Format
@@ -512,17 +431,6 @@ my.BaseControl = Backbone.View.extend({
       template += this.templateYFormat;
     }
 
-=======
-
-    if (this.state.get('graphType') === 'linePlusBarChart') {
-      template += this.templateY1Format
-      template += this.templateY2Format;
-      template += this.linePlusBarXSelect();
-    } else {
-      template += this.templateYFormat;
-    }
-
->>>>>>> 2222-fix-percent-formats
     template += this.templateGeneral;
     
     return template;
@@ -553,18 +461,12 @@ my.BaseControl = Backbone.View.extend({
     // subclasses define a template with extra controls
     // otherwise we're rendering the base controls using our compose method
     if (self.template) {
-<<<<<<< HEAD
       $('#extended-controls').html(Mustache.render(self.template), self.state.toJSON());
     } 
     
     if (!self.controlsRendered){
       self.controlsRendered = true;
       $('#base-controls').html(Mustache.render(self.composeTemplate(), self.state.toJSON()));
-=======
-      self.$el.html(Mustache.render(self.template), self.state.toJSON());
-    } else {
-      self.$el.html(Mustache.render(self.composeTemplate(), self.state.toJSON()));
->>>>>>> 2222-fix-percent-formats
     }
 
     self.$('.chosen-select').chosen({width: '95%'});

--- a/src/recline.view.nvd3.base.js
+++ b/src/recline.view.nvd3.base.js
@@ -115,13 +115,13 @@ var chartAxes = ['x','y','y1','y2'];
           if(self.graphType === 'discreteBarChart' && self.state.get('options') && self.state.get('options').reduceXTicks){
             self.reduceXTicks();
           }
-          console.log(self.chart);
           if (self.chart.tooltip) {self.chart.tooltip.enabled(self.state.get('options').tooltips)};
           nv.utils.windowResize(self.updateChart.bind(self));
           return self.chart;
         });
         return self;
       },
+      
       calcTickValues: function(axisName, axis, range, step){
         var self = this;
         var ordinalScaled = ['multiBarChart', 'discreteBarChart', 'linePlusBarChart'];
@@ -343,7 +343,6 @@ var chartAxes = ['x','y','y1','y2'];
       },
       getFormatter: function(type, format, axisName){
         var self = this;
-
         axisName = axisName || 'x';
 
         if(self.state.get('computeXLabels') && axisName === 'x')
@@ -359,15 +358,6 @@ var chartAxes = ['x','y','y1','y2'];
         };
         return formatter[type];
       },
-<<<<<<< HEAD
-      formatPercentage: function(format) {
-        if (format === 'd') format = 'r.0';
-        return function(d){
-          return d3.format(format)(d) + '%';
-        };
-      },
-=======
->>>>>>> 2222-fix-percent-formats
       setOptions: function (chart, options) {
         var self = this;
         for(var optionName in options){


### PR DESCRIPTION
ref: https://jira.govdelivery.com/browse/CIVIC-2222
- [ ] Charts should have additional percentage formatters
- [ ] .97 -> 97% should multiply by 100 and round to nearest whole number
- [ ] .97 -> 97.00% should multiply by 100 and preserve 2 degrees of precision
- [ ] 97 -> 97% rounds to integer and adds %
- [ ] 97 -> 97.00% preserves 2 degrees of precision